### PR TITLE
listener: dont stay in pool wait state for too long

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ Also you may share PROXY protocol, SOCKS protocol listener and decoy webserver o
 $ ptw --help
 usage: ptw [-h] [-v {debug,info,warn,error,fatal}] [-l FILE]
            [--disable-uvloop] [-a BIND_ADDRESS] [-p BIND_PORT]
-           [-P {none,v1,v2}] [-n POOL_SIZE] [-B BACKOFF] [-T TTL] [-w TIMEOUT]
-           [-c CERT] [-k KEY] [-C CAFILE]
+           [-W POOL_WAIT_TIMEOUT] [-P {none,v1,v2}] [-n POOL_SIZE]
+           [-B BACKOFF] [-T TTL] [-w TIMEOUT] [-c CERT] [-k KEY] [-C CAFILE]
            [--no-hostname-check | --tls-servername TLS_SERVERNAME]
            dst_address dst_port
 
@@ -148,6 +148,9 @@ listen options:
                         bind address (default: 127.0.0.1)
   -p BIND_PORT, --bind-port BIND_PORT
                         bind port (default: 57800)
+  -W POOL_WAIT_TIMEOUT, --pool-wait-timeout POOL_WAIT_TIMEOUT
+                        timeout for pool await state of client connection
+                        (default: 15)
   -P {none,v1,v2}, --proxy-protocol {none,v1,v2}
                         transparent mode: prepend all connections with proxy-
                         protocol data (default: none)

--- a/ptw/__main__.py
+++ b/ptw/__main__.py
@@ -46,6 +46,11 @@ def parse_args():
                               default=57800,
                               type=utils.check_port,
                               help="bind port")
+    listen_group.add_argument("-W", "--pool-wait-timeout",
+                              default=15,
+                              type=utils.check_port,
+                              help="timeout for pool await state of client "
+                              "connection")
     listen_group.add_argument("-P", "--proxy-protocol",
                               default=ProxyProtocol.none,
                               choices=ProxyProtocol,
@@ -124,7 +129,7 @@ async def amain(args, loop):  # pragma: no cover
     await pool.start()
     server = Listener(listen_address=args.bind_address,
                       listen_port=args.bind_port,
-                      timeout=args.timeout,
+                      timeout=args.pool_wait_timeout,
                       pool=pool,
                       proxy_protocol=proxy_protocol,
                       loop=loop)


### PR DESCRIPTION
Amount of accepted incoming connections tends to build up when there is no upstream connection available (e.g. no internet connection), effectively leading to fd limit hit. Also with asyncio stream API we can't handle disconnected clients without reading from socket. Therefore it is reasonable to restrict time which client handler spends in pool wait state.